### PR TITLE
Harden draft voice moves with retries, cooldowns, and winner lobby return

### DIFF
--- a/src/utils/draftWatcher.js
+++ b/src/utils/draftWatcher.js
@@ -4,13 +4,319 @@ const axios = require("axios");
 const CONVEX_URL = process.env.CONVEX_URL;
 const APP_URL = process.env.APP_URL || "https://divoxutils.com";
 const BOT_HEADERS = { headers: { "x-bot-api-key": process.env.BOT_API_KEY } };
+const POLL_INTERVAL_MS = 2000;
+const MOVE_CONCURRENCY = 5;
+const RETRY_DELAYS_MS = [250, 750];
+const PHASE_RETRY_COOLDOWN_MS = 10000;
+const CONFIG_RETRY_COOLDOWN_MS = 60000;
 const activePolls = new Set();
+const pollIntervals = new Map();
+const pollInFlight = new Set();
+const draftStateCache = new Map();
+
+function createInitialDraftState() {
+  return {
+    lastStatus: null,
+    lastGameStarted: null,
+    lastWinnerTeam: null,
+    lastMovePhase: "none",
+    nextTeamMoveAttemptAt: null,
+    nextLobbyMoveAttemptAt: null,
+  };
+}
+
+function getDraftState(shortId) {
+  if (!draftStateCache.has(shortId)) {
+    draftStateCache.set(shortId, createInitialDraftState());
+  }
+
+  return draftStateCache.get(shortId);
+}
+
+function isWinnerSet(value) {
+  return value !== undefined && value !== null && value !== "";
+}
+
+function isTeamMoveConditionMet(data) {
+  return data.status === "complete" && data.gameStarted === true && !isWinnerSet(data.winnerTeam);
+}
+
+function shouldTriggerTeamMove(prevState, data) {
+  if (!isTeamMoveConditionMet(data)) return false;
+  return prevState.lastMovePhase !== "moved_to_teams" && prevState.lastMovePhase !== "moved_to_lobby";
+}
+
+function shouldTriggerLobbyMove(prevState, data) {
+  const winnerNowSet = isWinnerSet(data.winnerTeam);
+  return winnerNowSet && prevState.lastMovePhase !== "moved_to_lobby";
+}
+
+function updateDraftState(shortId, data, movePhase) {
+  const currentState = getDraftState(shortId);
+  draftStateCache.set(shortId, {
+    ...currentState,
+    lastStatus: data.status ?? null,
+    lastGameStarted: data.gameStarted ?? null,
+    lastWinnerTeam: data.winnerTeam ?? null,
+    lastMovePhase: movePhase || "none",
+  });
+}
+
+function canAttemptMovePhase(state, phase, nowMs = Date.now()) {
+  const nextAttemptAt =
+    phase === "teams" ? state.nextTeamMoveAttemptAt : state.nextLobbyMoveAttemptAt;
+
+  return nextAttemptAt === null || nowMs >= nextAttemptAt;
+}
+
+function setNextAttemptAt(state, phase, nextAttemptAt) {
+  if (phase === "teams") {
+    return { ...state, nextTeamMoveAttemptAt: nextAttemptAt };
+  }
+
+  return { ...state, nextLobbyMoveAttemptAt: nextAttemptAt };
+}
+
+function resolvePhaseCooldownMs(operationResult) {
+  if (!operationResult) return null;
+  if (operationResult.terminalConfigError) return CONFIG_RETRY_COOLDOWN_MS;
+  if (operationResult.retryableFailures > 0 || operationResult.retryableError) {
+    return PHASE_RETRY_COOLDOWN_MS;
+  }
+  return null;
+}
+
+function stopWatchingDraft(shortId) {
+  const interval = pollIntervals.get(shortId);
+  if (interval) {
+    clearInterval(interval);
+  }
+
+  pollIntervals.delete(shortId);
+  pollInFlight.delete(shortId);
+  draftStateCache.delete(shortId);
+  activePolls.delete(shortId);
+}
+
+function resetWatcherInternals() {
+  for (const [, interval] of pollIntervals.entries()) {
+    clearInterval(interval);
+  }
+
+  pollIntervals.clear();
+  pollInFlight.clear();
+  draftStateCache.clear();
+  activePolls.clear();
+}
+
+function toErrorCode(error) {
+  return (
+    error?.code ??
+    error?.rawError?.code ??
+    error?.response?.status ??
+    error?.status ??
+    "unknown"
+  );
+}
+
+function toErrorMessage(error) {
+  if (error?.response?.data?.message) return String(error.response.data.message);
+  if (error?.message) return String(error.message);
+  return "unknown error";
+}
+
+function isTransientMoveError(error) {
+  const status = error?.response?.status ?? error?.status ?? null;
+  const code = String(error?.code ?? "");
+
+  if ([429, 500, 502, 503, 504].includes(status)) {
+    return true;
+  }
+
+  return ["ECONNRESET", "ECONNABORTED", "ETIMEDOUT", "EAI_AGAIN"].includes(code);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function runWithConcurrency(items, limit, worker) {
+  if (!items.length) return;
+
+  let index = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const nextIndex = index;
+      index += 1;
+      if (nextIndex >= items.length) break;
+      await worker(items[nextIndex]);
+    }
+  });
+
+  await Promise.all(workers);
+}
+
+function buildTeamMoveTasks(players, settings) {
+  return (players || [])
+    .filter((player) => Number(player.team) === 1 || Number(player.team) === 2)
+    .map((player) => ({
+      userId: player.discordUserId,
+      displayName: player.displayName,
+      targetChannelId:
+        Number(player.team) === 1 ? settings.team1ChannelId : settings.team2ChannelId,
+    }));
+}
+
+function buildLobbyMoveTasks(players, settings) {
+  const rosteredIds = new Set((players || []).map((player) => player.discordUserId).filter(Boolean));
+  return Array.from(rosteredIds).map((userId) => ({
+    userId,
+    targetChannelId: settings.lobbyChannelId,
+  }));
+}
+
+async function fetchGuildSettings(guildId) {
+  try {
+    const { data } = await axios.get(
+      `${CONVEX_URL}/guildSettings?discordGuildId=${guildId}`,
+      BOT_HEADERS
+    );
+    return data;
+  } catch (error) {
+    if (error?.response?.status !== 404) {
+      throw error;
+    }
+  }
+
+  try {
+    const { data } = await axios.get(`${CONVEX_URL}/guildSettings?guildId=${guildId}`, BOT_HEADERS);
+    return data;
+  } catch (error) {
+    if (error?.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function runMoveOperation({
+  guild,
+  tasks,
+  draftShortId,
+  phase,
+  allowedSourceChannelIds = null,
+  maxConcurrency = MOVE_CONCURRENCY,
+  retryDelaysMs = RETRY_DELAYS_MS,
+}) {
+  const startedAt = Date.now();
+  const summary = {
+    attempted: 0,
+    moved: 0,
+    alreadyInPlace: 0,
+    failed: 0,
+    retryableFailures: 0,
+    durationMs: 0,
+    retriesTotal: 0,
+  };
+  const failedMembers = [];
+  const allowedSources = allowedSourceChannelIds ? new Set(allowedSourceChannelIds) : null;
+
+  await runWithConcurrency(tasks, maxConcurrency, async (task) => {
+    let member;
+    try {
+      member = await guild.members.fetch(task.userId);
+    } catch (error) {
+      const retryable = isTransientMoveError(error);
+      summary.failed += 1;
+      if (retryable) {
+        summary.retryableFailures += 1;
+      }
+      failedMembers.push({
+        userId: task.userId,
+        code: toErrorCode(error),
+        message: toErrorMessage(error),
+      });
+      return;
+    }
+
+    const currentChannelId = member.voice?.channelId || null;
+    if (!currentChannelId) return;
+    if (currentChannelId === task.targetChannelId) {
+      summary.alreadyInPlace += 1;
+      return;
+    }
+    if (allowedSources && !allowedSources.has(currentChannelId)) return;
+
+    summary.attempted += 1;
+    let retriesForMember = 0;
+
+    for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+      try {
+        await member.voice.setChannel(task.targetChannelId);
+        summary.moved += 1;
+        summary.retriesTotal += retriesForMember;
+        return;
+      } catch (error) {
+        const shouldRetry =
+          isTransientMoveError(error) && attempt < retryDelaysMs.length;
+
+        if (shouldRetry) {
+          retriesForMember += 1;
+          await sleep(retryDelaysMs[attempt]);
+          continue;
+        }
+
+        summary.failed += 1;
+        if (isTransientMoveError(error)) {
+          summary.retryableFailures += 1;
+        }
+        summary.retriesTotal += retriesForMember;
+        failedMembers.push({
+          userId: task.userId,
+          code: toErrorCode(error),
+          message: toErrorMessage(error),
+        });
+        return;
+      }
+    }
+  });
+
+  summary.durationMs = Date.now() - startedAt;
+  const durationMetricName =
+    phase === "teams"
+      ? "draft_voice_move_team_duration_ms"
+      : "draft_voice_move_lobby_duration_ms";
+
+  console.log(`[draft_voice_move] ${phase} summary`, {
+    shortId: draftShortId,
+    ...summary,
+  });
+  console.log(`[metric] ${durationMetricName}`, summary.durationMs);
+  console.log("[metric] draft_voice_move_members_attempted", summary.attempted);
+  console.log("[metric] draft_voice_move_members_failed", summary.failed);
+  console.log("[metric] draft_voice_move_retries_total", summary.retriesTotal);
+
+  if (failedMembers.length > 0) {
+    console.error(`[draft_voice_move] ${phase} failed_members`, {
+      shortId: draftShortId,
+      failedMembers,
+    });
+  }
+
+  return summary;
+}
 
 function watchDraft(client, shortId) {
   if (activePolls.has(shortId)) return;
   activePolls.add(shortId);
+  getDraftState(shortId);
 
   const interval = setInterval(async () => {
+    if (pollInFlight.has(shortId)) return;
+    pollInFlight.add(shortId);
+
     try {
       const { data } = await axios.get(
         `${CONVEX_URL}/getDraftStatus?shortId=${shortId}`,
@@ -36,15 +342,53 @@ function watchDraft(client, shortId) {
         await axios.post(`${CONVEX_URL}/markBotNotifiedCaptains`, { shortId }, BOT_HEADERS);
       }
 
-      if (data.gameStarted && data.status === "complete") {
-        clearInterval(interval);
-        activePolls.delete(shortId);
-        await movePlayersToChannels(client, data, data.discordGuildId);
+      const currentState = getDraftState(shortId);
+      let nextMovePhase = currentState.lastMovePhase;
+      let nextState = { ...currentState };
+      const nowMs = Date.now();
+
+      if (shouldTriggerTeamMove(currentState, data) && canAttemptMovePhase(currentState, "teams", nowMs)) {
+        const teamMoveResult = await movePlayersToTeamChannels(client, shortId, data);
+        if (teamMoveResult.completed) {
+          nextMovePhase = "moved_to_teams";
+          nextState = setNextAttemptAt(nextState, "teams", null);
+        } else {
+          const cooldownMs = resolvePhaseCooldownMs(teamMoveResult);
+          if (cooldownMs !== null) {
+            nextState = setNextAttemptAt(nextState, "teams", nowMs + cooldownMs);
+          }
+        }
       }
+
+      if (shouldTriggerLobbyMove(currentState, data) && canAttemptMovePhase(currentState, "lobby", nowMs)) {
+        const lobbyMoveResult = await movePlayersToLobby(client, shortId, data);
+        if (lobbyMoveResult.completed) {
+          nextMovePhase = "moved_to_lobby";
+          updateDraftState(shortId, data, nextMovePhase);
+          stopWatchingDraft(shortId);
+          return;
+        } else {
+          const cooldownMs = resolvePhaseCooldownMs(lobbyMoveResult);
+          if (cooldownMs !== null) {
+            nextState = setNextAttemptAt(nextState, "lobby", nowMs + cooldownMs);
+          }
+        }
+      }
+
+      updateDraftState(shortId, data, nextMovePhase);
+      draftStateCache.set(shortId, {
+        ...draftStateCache.get(shortId),
+        nextTeamMoveAttemptAt: nextState.nextTeamMoveAttemptAt,
+        nextLobbyMoveAttemptAt: nextState.nextLobbyMoveAttemptAt,
+      });
     } catch (error) {
       console.error(`Error polling draft ${shortId}:`, error.message);
+    } finally {
+      pollInFlight.delete(shortId);
     }
-  }, 5000);
+  }, POLL_INTERVAL_MS);
+
+  pollIntervals.set(shortId, interval);
 }
 
 async function rehydrate(client) {
@@ -109,50 +453,115 @@ async function dmCaptains(client, shortId, draftData, tokens) {
   }
 }
 
-async function movePlayersToChannels(client, draftData, guildId) {
+async function movePlayersToTeamChannels(client, shortId, draftData) {
+  const guildId = draftData.discordGuildId || draftData.guildId;
+
+  if (!guildId) {
+    console.log(`[draft_voice_move] teams missing guildId for ${shortId}, skipping.`);
+    return { executed: false, completed: false, terminalConfigError: true };
+  }
+
   try {
-    const { data: settings } = await axios.get(
-      `${CONVEX_URL}/guildSettings?guildId=${guildId}`,
-      BOT_HEADERS
-    );
+    const settings = await fetchGuildSettings(guildId);
 
     if (!settings || !settings.team1ChannelId || !settings.team2ChannelId) {
       console.log(
-        `No channel settings for guild ${guildId}, skipping moves.`
+        `No channel settings for guild ${guildId}, skipping team moves.`
       );
-      return;
+      return { executed: false, completed: false, terminalConfigError: true };
     }
 
     const guild = await client.guilds.fetch(guildId);
+    const tasks = buildTeamMoveTasks(draftData.players, settings);
+    const summary = await runMoveOperation({
+      guild,
+      tasks,
+      draftShortId: shortId,
+      phase: "teams",
+    });
 
-    for (const player of draftData.players) {
-      if (!player.team) continue;
-
-      const channelId =
-        player.team === 1 ? settings.team1ChannelId : settings.team2ChannelId;
-
-      try {
-        const member = await guild.members.fetch(player.discordUserId);
-        if (member.voice?.channelId) {
-          await member.voice.setChannel(channelId);
-        }
-      } catch (err) {
-        console.error(
-          `Could not move ${player.displayName}: ${err.message}`
-        );
-      }
-    }
-
-    console.log(`Moved players for draft in guild ${guildId}`);
+    return {
+      executed: true,
+      completed: summary.retryableFailures === 0,
+      retryableFailures: summary.retryableFailures,
+    };
   } catch (error) {
-    if (error?.response?.status === 404) {
-      console.log(
-        `No channel settings for guild ${guildId}, skipping moves.`
-      );
-    } else {
-      console.error("Error moving players:", error.message);
-    }
+    console.error("Error moving players to team channels:", error.message);
+    return {
+      executed: false,
+      completed: false,
+      retryableError: isTransientMoveError(error),
+      error,
+    };
   }
 }
 
-module.exports = { watchDraft, rehydrate };
+async function movePlayersToLobby(client, shortId, draftData) {
+  const guildId = draftData.discordGuildId || draftData.guildId;
+
+  if (!guildId) {
+    console.log(`[draft_voice_move] lobby missing guildId for ${shortId}, skipping.`);
+    return { executed: false, completed: false, terminalConfigError: true };
+  }
+
+  try {
+    const settings = await fetchGuildSettings(guildId);
+
+    if (
+      !settings ||
+      !settings.team1ChannelId ||
+      !settings.team2ChannelId ||
+      !settings.lobbyChannelId
+    ) {
+      console.log(
+        `No channel settings for guild ${guildId}, skipping lobby moves.`
+      );
+      return { executed: false, completed: false, terminalConfigError: true };
+    }
+
+    const guild = await client.guilds.fetch(guildId);
+    const tasks = buildLobbyMoveTasks(draftData.players, settings);
+    const summary = await runMoveOperation({
+      guild,
+      tasks,
+      draftShortId: shortId,
+      phase: "lobby",
+      allowedSourceChannelIds: [settings.team1ChannelId, settings.team2ChannelId],
+    });
+
+    return {
+      executed: true,
+      completed: summary.retryableFailures === 0,
+      retryableFailures: summary.retryableFailures,
+    };
+  } catch (error) {
+    console.error("Error moving players to lobby:", error.message);
+    return {
+      executed: false,
+      completed: false,
+      retryableError: isTransientMoveError(error),
+      error,
+    };
+  }
+}
+
+module.exports = {
+  watchDraft,
+  rehydrate,
+  __testables: {
+    buildTeamMoveTasks,
+    buildLobbyMoveTasks,
+    runMoveOperation,
+    shouldTriggerTeamMove,
+    shouldTriggerLobbyMove,
+    createInitialDraftState,
+    updateDraftState,
+    canAttemptMovePhase,
+    resolvePhaseCooldownMs,
+    setNextAttemptAt,
+    resetWatcherInternals,
+    stopWatchingDraft,
+    isTransientMoveError,
+    fetchGuildSettings,
+  },
+};

--- a/src/utils/draftWatcher.test.js
+++ b/src/utils/draftWatcher.test.js
@@ -1,0 +1,368 @@
+const axios = require("axios");
+const { watchDraft, __testables } = require("./draftWatcher");
+
+jest.mock("axios");
+
+describe("draftWatcher move operations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    __testables.resetWatcherInternals();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    __testables.resetWatcherInternals();
+    jest.useRealTimers();
+  });
+
+  test("runMoveOperation enforces concurrency and retries transient failures", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const attemptsByUser = new Map();
+    const members = new Map();
+
+    for (let i = 1; i <= 16; i += 1) {
+      const userId = `user-${i}`;
+      members.set(userId, {
+        voice: {
+          channelId: "source",
+          setChannel: jest.fn(async () => {
+            const currentAttempts = attemptsByUser.get(userId) || 0;
+            attemptsByUser.set(userId, currentAttempts + 1);
+
+            if (userId === "user-3" && currentAttempts < 2) {
+              const transientError = new Error("temporary failure");
+              transientError.status = 500;
+              throw transientError;
+            }
+
+            inFlight += 1;
+            if (inFlight > maxInFlight) {
+              maxInFlight = inFlight;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            inFlight -= 1;
+          }),
+        },
+      });
+    }
+
+    const guild = {
+      members: {
+        fetch: jest.fn(async (userId) => members.get(userId)),
+      },
+    };
+
+    const tasks = Array.from({ length: 16 }, (_, index) => ({
+      userId: `user-${index + 1}`,
+      targetChannelId: "target",
+    }));
+
+    const summary = await __testables.runMoveOperation({
+      guild,
+      tasks,
+      draftShortId: "short-1",
+      phase: "teams",
+      maxConcurrency: 5,
+      retryDelaysMs: [1, 1],
+    });
+
+    expect(summary.attempted).toBe(16);
+    expect(summary.moved).toBe(16);
+    expect(summary.failed).toBe(0);
+    expect(summary.retryableFailures).toBe(0);
+    expect(summary.alreadyInPlace).toBe(0);
+    expect(summary.retriesTotal).toBe(2);
+    expect(maxInFlight).toBeLessThanOrEqual(5);
+  });
+
+  test("runMoveOperation is idempotent for lobby moves", async () => {
+    const members = new Map([
+      [
+        "user-a",
+        {
+          voice: {
+            channelId: "lobby",
+            setChannel: jest.fn(),
+          },
+        },
+      ],
+      [
+        "user-b",
+        {
+          voice: {
+            channelId: "team-1",
+            setChannel: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+      [
+        "user-c",
+        {
+          voice: {
+            channelId: "other",
+            setChannel: jest.fn(),
+          },
+        },
+      ],
+      [
+        "user-d",
+        {
+          voice: {
+            channelId: null,
+            setChannel: jest.fn(),
+          },
+        },
+      ],
+    ]);
+
+    const guild = {
+      members: {
+        fetch: jest.fn(async (userId) => members.get(userId)),
+      },
+    };
+
+    const summary = await __testables.runMoveOperation({
+      guild,
+      tasks: [
+        { userId: "user-a", targetChannelId: "lobby" },
+        { userId: "user-b", targetChannelId: "lobby" },
+        { userId: "user-c", targetChannelId: "lobby" },
+        { userId: "user-d", targetChannelId: "lobby" },
+      ],
+      draftShortId: "short-2",
+      phase: "lobby",
+      allowedSourceChannelIds: ["team-1", "team-2"],
+      maxConcurrency: 5,
+      retryDelaysMs: [1, 1],
+    });
+
+    expect(summary.attempted).toBe(1);
+    expect(summary.moved).toBe(1);
+    expect(summary.alreadyInPlace).toBe(1);
+    expect(summary.failed).toBe(0);
+    expect(summary.retryableFailures).toBe(0);
+  });
+
+  test("runMoveOperation marks retryable failures separately", async () => {
+    const guild = {
+      members: {
+        fetch: jest.fn(async () => ({
+          voice: {
+            channelId: "source",
+            setChannel: jest.fn(async () => {
+              const err = new Error("temporary");
+              err.status = 503;
+              throw err;
+            }),
+          },
+        })),
+      },
+    };
+
+    const summary = await __testables.runMoveOperation({
+      guild,
+      tasks: [{ userId: "user-z", targetChannelId: "target" }],
+      draftShortId: "short-3",
+      phase: "teams",
+      maxConcurrency: 1,
+      retryDelaysMs: [1, 1],
+    });
+
+    expect(summary.attempted).toBe(1);
+    expect(summary.moved).toBe(0);
+    expect(summary.failed).toBe(1);
+    expect(summary.retryableFailures).toBe(1);
+  });
+});
+
+describe("draftWatcher transition and settings helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("team and lobby transitions use phase completion to gate repeat runs", () => {
+    const initial = __testables.createInitialDraftState();
+
+    expect(
+      __testables.shouldTriggerTeamMove(initial, {
+        status: "complete",
+        gameStarted: true,
+        winnerTeam: null,
+      })
+    ).toBe(true);
+
+    expect(
+      __testables.shouldTriggerTeamMove(
+        {
+          lastStatus: "complete",
+          lastGameStarted: true,
+          lastWinnerTeam: null,
+          lastMovePhase: "moved_to_teams",
+        },
+        {
+          status: "complete",
+          gameStarted: true,
+          winnerTeam: null,
+        }
+      )
+    ).toBe(false);
+
+    expect(
+      __testables.shouldTriggerLobbyMove(
+        {
+          lastStatus: "complete",
+          lastGameStarted: true,
+          lastWinnerTeam: null,
+          lastMovePhase: "moved_to_teams",
+        },
+        {
+          status: "complete",
+          gameStarted: true,
+          winnerTeam: 2,
+        }
+      )
+    ).toBe(true);
+
+    expect(
+      __testables.shouldTriggerLobbyMove(
+        {
+          lastStatus: "complete",
+          lastGameStarted: true,
+          lastWinnerTeam: 2,
+          lastMovePhase: "moved_to_teams",
+        },
+        {
+          status: "complete",
+          gameStarted: true,
+          winnerTeam: 2,
+        }
+      )
+    ).toBe(true);
+
+    expect(
+      __testables.shouldTriggerLobbyMove(
+        {
+          lastStatus: "complete",
+          lastGameStarted: true,
+          lastWinnerTeam: 2,
+          lastMovePhase: "moved_to_lobby",
+        },
+        {
+          status: "complete",
+          gameStarted: true,
+          winnerTeam: 2,
+        }
+      )
+    ).toBe(false);
+  });
+
+  test("phase cooldown helpers gate repeated attempts", () => {
+    const state = __testables.createInitialDraftState();
+    const updated = __testables.setNextAttemptAt(state, "teams", 10_000);
+
+    expect(__testables.canAttemptMovePhase(updated, "teams", 9_999)).toBe(false);
+    expect(__testables.canAttemptMovePhase(updated, "teams", 10_000)).toBe(true);
+    expect(__testables.resolvePhaseCooldownMs({ terminalConfigError: true })).toBe(60_000);
+    expect(__testables.resolvePhaseCooldownMs({ retryableFailures: 1 })).toBe(10_000);
+  });
+
+  test("fetchGuildSettings falls back to guildId endpoint", async () => {
+    axios.get
+      .mockRejectedValueOnce({ response: { status: 404 } })
+      .mockResolvedValueOnce({ data: { team1ChannelId: "a", team2ChannelId: "b" } });
+
+    const result = await __testables.fetchGuildSettings("guild-1");
+
+    expect(result).toEqual({ team1ChannelId: "a", team2ChannelId: "b" });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get.mock.calls[0][0]).toContain("discordGuildId=guild-1");
+    expect(axios.get.mock.calls[1][0]).toContain("guildId=guild-1");
+  });
+});
+
+describe("draftWatcher poll hardening", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    __testables.resetWatcherInternals();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    __testables.resetWatcherInternals();
+    jest.useRealTimers();
+  });
+
+  test("retryable failures back off phase retries instead of retrying every poll", async () => {
+    const setChannel = jest.fn(async () => {
+      const error = new Error("temporary");
+      error.status = 503;
+      throw error;
+    });
+
+    const client = {
+      guilds: {
+        fetch: jest.fn(async () => ({
+          members: {
+            fetch: jest.fn(async () => ({
+              voice: {
+                channelId: "source-voice",
+                setChannel,
+              },
+            })),
+          },
+        })),
+      },
+      channels: {
+        fetch: jest.fn(),
+      },
+      users: {
+        fetch: jest.fn(),
+      },
+    };
+
+    axios.get.mockImplementation(async (url) => {
+      if (url.includes("/getDraftStatus?shortId=short-backoff")) {
+        return {
+          data: {
+            shortId: "short-backoff",
+            status: "complete",
+            gameStarted: true,
+            winnerTeam: null,
+            discordGuildId: "guild-1",
+            players: [{ discordUserId: "user-1", team: 1 }],
+          },
+        };
+      }
+
+      if (url.includes("/guildSettings?discordGuildId=guild-1")) {
+        return {
+          data: {
+            team1ChannelId: "team-1",
+            team2ChannelId: "team-2",
+            lobbyChannelId: "lobby",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    watchDraft(client, "short-backoff");
+    await jest.advanceTimersByTimeAsync(3500);
+    expect(setChannel).toHaveBeenCalledTimes(3);
+
+    await jest.advanceTimersByTimeAsync(8000);
+    expect(setChannel).toHaveBeenCalledTimes(3);
+
+    await jest.advanceTimersByTimeAsync(3000);
+    expect(setChannel).toHaveBeenCalledTimes(6);
+
+    __testables.stopWatchingDraft("short-backoff");
+  });
+});


### PR DESCRIPTION
## Summary
- Refactor draft watcher to poll every 2s with per-draft state tracking (`lastStatus`, `lastGameStarted`, `lastWinnerTeam`, `lastMovePhase`).
- Implement robust batch voice move engine with:
  - bounded concurrency (5)
  - transient retry backoff (250ms, 750ms)
  - idempotent skip handling (already in channel, disconnected, self-moved)
  - per-operation summaries and failed-member logging
- Add winner-triggered move-back-to-lobby flow for rostered members currently in team channels.
- Add guild settings compatibility path: prefer `discordGuildId`, fallback to `guildId`.
- Add hardening cooldowns to avoid repeated 2s hammering when failures persist:
  - retryable failures: 10s
  - terminal config errors: 60s

## Why
Large drafts were at risk of slow/sequential moves and one-shot failure modes. This change improves throughput, resiliency, and idempotency while preserving existing draft notifications.

## Test Plan
- [x] `npm test -- --runInBand`
- [x] Verified new `draftWatcher` tests for:
  - concurrency limit and retry behavior
  - idempotent lobby move behavior
  - transition gating behavior
  - guild settings fallback behavior
  - timer-driven poll backoff/cooldown behavior
- [x] Verified existing command tests still pass

## Risk / Rollback
- Risk is low-to-moderate and concentrated in watcher behavior.
- Rollback path: revert `src/utils/draftWatcher.js` and `src/utils/draftWatcher.test.js`.