### PR TITLE
Fix draft voice move guildSettings 400 fallback and error-loop cooldown

### DIFF
--- a/src/utils/draftWatcher.js
+++ b/src/utils/draftWatcher.js
@@ -9,6 +9,7 @@ const MOVE_CONCURRENCY = 5;
 const RETRY_DELAYS_MS = [250, 750];
 const PHASE_RETRY_COOLDOWN_MS = 10000;
 const CONFIG_RETRY_COOLDOWN_MS = 60000;
+const NON_RETRYABLE_ERROR_COOLDOWN_MS = 60000;
 const activePolls = new Set();
 const pollIntervals = new Map();
 const pollInFlight = new Set();
@@ -82,6 +83,9 @@ function resolvePhaseCooldownMs(operationResult) {
   if (operationResult.terminalConfigError) return CONFIG_RETRY_COOLDOWN_MS;
   if (operationResult.retryableFailures > 0 || operationResult.retryableError) {
     return PHASE_RETRY_COOLDOWN_MS;
+  }
+  if (operationResult.executed === false || operationResult.retryableFailures === 0) {
+    return NON_RETRYABLE_ERROR_COOLDOWN_MS;
   }
   return null;
 }
@@ -185,7 +189,7 @@ async function fetchGuildSettings(guildId) {
     );
     return data;
   } catch (error) {
-    if (error?.response?.status !== 404) {
+    if (error?.response?.status !== 404 && error?.response?.status !== 400) {
       throw error;
     }
   }

--- a/src/utils/draftWatcher.test.js
+++ b/src/utils/draftWatcher.test.js
@@ -267,11 +267,25 @@ describe("draftWatcher transition and settings helpers", () => {
     expect(__testables.canAttemptMovePhase(updated, "teams", 10_000)).toBe(true);
     expect(__testables.resolvePhaseCooldownMs({ terminalConfigError: true })).toBe(60_000);
     expect(__testables.resolvePhaseCooldownMs({ retryableFailures: 1 })).toBe(10_000);
+    expect(__testables.resolvePhaseCooldownMs({ executed: false, retryableError: false })).toBe(60_000);
   });
 
   test("fetchGuildSettings falls back to guildId endpoint", async () => {
     axios.get
       .mockRejectedValueOnce({ response: { status: 404 } })
+      .mockResolvedValueOnce({ data: { team1ChannelId: "a", team2ChannelId: "b" } });
+
+    const result = await __testables.fetchGuildSettings("guild-1");
+
+    expect(result).toEqual({ team1ChannelId: "a", team2ChannelId: "b" });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(axios.get.mock.calls[0][0]).toContain("discordGuildId=guild-1");
+    expect(axios.get.mock.calls[1][0]).toContain("guildId=guild-1");
+  });
+
+  test("fetchGuildSettings falls back to guildId endpoint on 400", async () => {
+    axios.get
+      .mockRejectedValueOnce({ response: { status: 400 } })
       .mockResolvedValueOnce({ data: { team1ChannelId: "a", team2ChannelId: "b" } });
 
     const result = await __testables.fetchGuildSettings("guild-1");


### PR DESCRIPTION
## Summary
- Fixes draft voice moves failing when `GET /guildSettings?discordGuildId=...` returns `400`.
- Updates `fetchGuildSettings` to fallback to `guildId` lookup on both `400` and `404`.
- Adds non-retryable failure cooldown to phase retries to prevent repeated 2s error loops.
- Keeps existing retry/backoff behavior for transient failures unchanged.

## Why
Production logs showed repeated:
`Error moving players to team channels: Request failed with status code 400`
This prevented team moves from executing and caused repeated polling error noise.

## Changes
- `src/utils/draftWatcher.js`
  - Add `NON_RETRYABLE_ERROR_COOLDOWN_MS = 60000`
  - Update `resolvePhaseCooldownMs(...)` to apply cooldown for non-retryable failed operations.
  - Update `fetchGuildSettings(...)` fallback criteria:
    - primary `discordGuildId` request now falls back on `400` and `404`
- `src/utils/draftWatcher.test.js`
  - Add test for fallback when `discordGuildId` request returns `400`
  - Add test for non-retryable cooldown behavior

## Test Plan
- [x] `npm test -- --runInBand`
- [x] Verify `draftWatcher` tests include:
  - fallback on `400`
  - fallback on `404`
  - cooldown behavior for non-retryable operation results

## Expected Production Impact
- Team/lobby moves recover when backend rejects `discordGuildId` query shape with `400`.
- Error storms are reduced by cooldown on non-retryable failures.
- No change to happy-path move behavior.