### PR TITLE
Optimize draft voice moves for large lobbies and faster recovery

### DIFF
--- a/src/utils/draftWatcher.js
+++ b/src/utils/draftWatcher.js
@@ -5,9 +5,10 @@ const CONVEX_URL = process.env.CONVEX_URL;
 const APP_URL = process.env.APP_URL || "https://divoxutils.com";
 const BOT_HEADERS = { headers: { "x-bot-api-key": process.env.BOT_API_KEY } };
 const POLL_INTERVAL_MS = 2000;
-const MOVE_CONCURRENCY = 5;
-const RETRY_DELAYS_MS = [250, 750];
-const PHASE_RETRY_COOLDOWN_MS = 10000;
+const MOVE_CONCURRENCY = 8;
+const MAX_MOVE_CONCURRENCY = 10;
+const RETRY_DELAYS_MS = [300, 800, 1500];
+const PHASE_RETRY_COOLDOWN_MS = POLL_INTERVAL_MS;
 const CONFIG_RETRY_COOLDOWN_MS = 60000;
 const NON_RETRYABLE_ERROR_COOLDOWN_MS = 60000;
 const activePolls = new Set();
@@ -146,6 +147,35 @@ function sleep(ms) {
   });
 }
 
+function toRetryAfterMs(error) {
+  const retryAfter =
+    error?.retry_after ??
+    error?.rawError?.retry_after ??
+    error?.data?.retry_after ??
+    error?.response?.data?.retry_after;
+
+  if (typeof retryAfter !== "number" || Number.isNaN(retryAfter) || retryAfter <= 0) {
+    return null;
+  }
+
+  if (retryAfter < 100) {
+    return Math.ceil(retryAfter * 1000);
+  }
+
+  return Math.ceil(retryAfter);
+}
+
+function resolveRetryDelayMs(error, attempt, retryDelaysMs) {
+  const rateLimitDelayMs = toRetryAfterMs(error);
+  if (rateLimitDelayMs !== null) {
+    return Math.min(3000, Math.max(250, rateLimitDelayMs));
+  }
+
+  const baseDelay =
+    retryDelaysMs[Math.min(attempt, Math.max(0, retryDelaysMs.length - 1))] ?? 750;
+  return Math.min(3000, baseDelay);
+}
+
 async function runWithConcurrency(items, limit, worker) {
   if (!items.length) return;
 
@@ -160,6 +190,32 @@ async function runWithConcurrency(items, limit, worker) {
   });
 
   await Promise.all(workers);
+}
+
+function normalizeMoveTasks(tasks) {
+  const uniqueTaskByUserId = new Map();
+  for (const task of tasks || []) {
+    if (!task?.userId) continue;
+    uniqueTaskByUserId.set(task.userId, task);
+  }
+  return Array.from(uniqueTaskByUserId.values());
+}
+
+function resolveMoveConcurrency(taskCount, requestedConcurrency = null) {
+  if (typeof requestedConcurrency === "number" && requestedConcurrency > 0) {
+    return Math.min(MAX_MOVE_CONCURRENCY, requestedConcurrency);
+  }
+
+  if (!taskCount || taskCount <= 0) return 1;
+  if (taskCount <= 4) return Math.min(4, taskCount);
+  if (taskCount <= 8) return Math.min(6, taskCount);
+  return Math.min(MAX_MOVE_CONCURRENCY, MOVE_CONCURRENCY);
+}
+
+async function resolveGuildMember(guild, userId) {
+  const cachedMember = guild?.members?.cache?.get?.(userId);
+  if (cachedMember) return cachedMember;
+  return guild.members.fetch(userId);
 }
 
 function buildTeamMoveTasks(players, settings) {
@@ -211,9 +267,11 @@ async function runMoveOperation({
   draftShortId,
   phase,
   allowedSourceChannelIds = null,
-  maxConcurrency = MOVE_CONCURRENCY,
+  maxConcurrency = null,
   retryDelaysMs = RETRY_DELAYS_MS,
 }) {
+  const normalizedTasks = normalizeMoveTasks(tasks);
+  const concurrency = resolveMoveConcurrency(normalizedTasks.length, maxConcurrency);
   const startedAt = Date.now();
   const summary = {
     attempted: 0,
@@ -221,16 +279,18 @@ async function runMoveOperation({
     alreadyInPlace: 0,
     failed: 0,
     retryableFailures: 0,
+    rateLimitFailures: 0,
     durationMs: 0,
     retriesTotal: 0,
+    concurrencyUsed: concurrency,
   };
   const failedMembers = [];
   const allowedSources = allowedSourceChannelIds ? new Set(allowedSourceChannelIds) : null;
 
-  await runWithConcurrency(tasks, maxConcurrency, async (task) => {
+  await runWithConcurrency(normalizedTasks, concurrency, async (task) => {
     let member;
     try {
-      member = await guild.members.fetch(task.userId);
+      member = await resolveGuildMember(guild, task.userId);
     } catch (error) {
       const retryable = isTransientMoveError(error);
       summary.failed += 1;
@@ -268,13 +328,16 @@ async function runMoveOperation({
 
         if (shouldRetry) {
           retriesForMember += 1;
-          await sleep(retryDelaysMs[attempt]);
+          await sleep(resolveRetryDelayMs(error, attempt, retryDelaysMs));
           continue;
         }
 
         summary.failed += 1;
         if (isTransientMoveError(error)) {
           summary.retryableFailures += 1;
+        }
+        if ((error?.response?.status ?? error?.status ?? null) === 429) {
+          summary.rateLimitFailures += 1;
         }
         summary.retriesTotal += retriesForMember;
         failedMembers.push({
@@ -301,6 +364,8 @@ async function runMoveOperation({
   console.log("[metric] draft_voice_move_members_attempted", summary.attempted);
   console.log("[metric] draft_voice_move_members_failed", summary.failed);
   console.log("[metric] draft_voice_move_retries_total", summary.retriesTotal);
+  console.log("[metric] draft_voice_move_concurrency_used", summary.concurrencyUsed);
+  console.log("[metric] draft_voice_move_rate_limit_failures", summary.rateLimitFailures);
 
   if (failedMembers.length > 0) {
     console.error(`[draft_voice_move] ${phase} failed_members`, {
@@ -566,6 +631,11 @@ module.exports = {
     resetWatcherInternals,
     stopWatchingDraft,
     isTransientMoveError,
+    resolveRetryDelayMs,
+    toRetryAfterMs,
+    resolveMoveConcurrency,
+    normalizeMoveTasks,
+    resolveGuildMember,
     fetchGuildSettings,
   },
 };

--- a/src/utils/draftWatcher.test.js
+++ b/src/utils/draftWatcher.test.js
@@ -75,6 +75,7 @@ describe("draftWatcher move operations", () => {
     expect(summary.retryableFailures).toBe(0);
     expect(summary.alreadyInPlace).toBe(0);
     expect(summary.retriesTotal).toBe(2);
+    expect(summary.concurrencyUsed).toBe(5);
     expect(maxInFlight).toBeLessThanOrEqual(5);
   });
 
@@ -176,6 +177,35 @@ describe("draftWatcher move operations", () => {
     expect(summary.failed).toBe(1);
     expect(summary.retryableFailures).toBe(1);
   });
+
+  test("runMoveOperation uses cached guild members when available", async () => {
+    const cachedMember = {
+      voice: {
+        channelId: "source",
+        setChannel: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+    const fetch = jest.fn(async () => {
+      throw new Error("should not fetch when member exists in cache");
+    });
+    const guild = {
+      members: {
+        cache: new Map([["cached-user", cachedMember]]),
+        fetch,
+      },
+    };
+
+    const summary = await __testables.runMoveOperation({
+      guild,
+      tasks: [{ userId: "cached-user", targetChannelId: "target" }],
+      draftShortId: "short-cache",
+      phase: "teams",
+      retryDelaysMs: [1, 1],
+    });
+
+    expect(summary.moved).toBe(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("draftWatcher transition and settings helpers", () => {
@@ -266,8 +296,36 @@ describe("draftWatcher transition and settings helpers", () => {
     expect(__testables.canAttemptMovePhase(updated, "teams", 9_999)).toBe(false);
     expect(__testables.canAttemptMovePhase(updated, "teams", 10_000)).toBe(true);
     expect(__testables.resolvePhaseCooldownMs({ terminalConfigError: true })).toBe(60_000);
-    expect(__testables.resolvePhaseCooldownMs({ retryableFailures: 1 })).toBe(10_000);
+    expect(__testables.resolvePhaseCooldownMs({ retryableFailures: 1 })).toBe(2_000);
     expect(__testables.resolvePhaseCooldownMs({ executed: false, retryableError: false })).toBe(60_000);
+  });
+
+  test("resolveRetryDelayMs prefers rate-limit retry_after values", () => {
+    const shortDelay = __testables.resolveRetryDelayMs(
+      { status: 429, rawError: { retry_after: 0.8 } },
+      0,
+      [300, 800, 1500]
+    );
+    const longDelay = __testables.resolveRetryDelayMs(
+      { status: 429, rawError: { retry_after: 25_000 } },
+      1,
+      [300, 800, 1500]
+    );
+
+    expect(shortDelay).toBe(800);
+    expect(longDelay).toBe(3000);
+  });
+
+  test("toRetryAfterMs treats larger retry_after as seconds when needed", () => {
+    expect(__testables.toRetryAfterMs({ rawError: { retry_after: 45 } })).toBe(45_000);
+    expect(__testables.toRetryAfterMs({ rawError: { retry_after: 1200 } })).toBe(1200);
+  });
+
+  test("resolveMoveConcurrency scales for larger rosters", () => {
+    expect(__testables.resolveMoveConcurrency(2)).toBe(2);
+    expect(__testables.resolveMoveConcurrency(8)).toBe(6);
+    expect(__testables.resolveMoveConcurrency(16)).toBe(8);
+    expect(__testables.resolveMoveConcurrency(16, 12)).toBe(10);
   });
 
   test("fetchGuildSettings falls back to guildId endpoint", async () => {
@@ -312,7 +370,7 @@ describe("draftWatcher poll hardening", () => {
     jest.useRealTimers();
   });
 
-  test("retryable failures back off phase retries instead of retrying every poll", async () => {
+  test("retryable failures re-attempt before a full 10s stall", async () => {
     const setChannel = jest.fn(async () => {
       const error = new Error("temporary");
       error.status = 503;
@@ -368,15 +426,88 @@ describe("draftWatcher poll hardening", () => {
     });
 
     watchDraft(client, "short-backoff");
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(setChannel).toHaveBeenCalledTimes(4);
+
     await jest.advanceTimersByTimeAsync(3500);
-    expect(setChannel).toHaveBeenCalledTimes(3);
-
-    await jest.advanceTimersByTimeAsync(8000);
-    expect(setChannel).toHaveBeenCalledTimes(3);
-
-    await jest.advanceTimersByTimeAsync(3000);
-    expect(setChannel).toHaveBeenCalledTimes(6);
+    expect(setChannel.mock.calls.length).toBeGreaterThan(4);
 
     __testables.stopWatchingDraft("short-backoff");
+  });
+
+  test("lobby retries also re-attempt quickly for winner-triggered return", async () => {
+    const setChannel = jest.fn(async () => {
+      const error = new Error("temporary");
+      error.status = 503;
+      throw error;
+    });
+
+    const client = {
+      guilds: {
+        fetch: jest.fn(async () => ({
+          members: {
+            cache: new Map([
+              [
+                "user-1",
+                {
+                  voice: {
+                    channelId: "team-1",
+                    setChannel,
+                  },
+                },
+              ],
+            ]),
+            fetch: jest.fn(async () => ({
+              voice: {
+                channelId: "team-1",
+                setChannel,
+              },
+            })),
+          },
+        })),
+      },
+      channels: {
+        fetch: jest.fn(),
+      },
+      users: {
+        fetch: jest.fn(),
+      },
+    };
+
+    axios.get.mockImplementation(async (url) => {
+      if (url.includes("/getDraftStatus?shortId=short-lobby-backoff")) {
+        return {
+          data: {
+            shortId: "short-lobby-backoff",
+            status: "complete",
+            gameStarted: true,
+            winnerTeam: 1,
+            discordGuildId: "guild-1",
+            players: [{ discordUserId: "user-1", team: 1 }],
+          },
+        };
+      }
+
+      if (url.includes("/guildSettings?discordGuildId=guild-1")) {
+        return {
+          data: {
+            team1ChannelId: "team-1",
+            team2ChannelId: "team-2",
+            lobbyChannelId: "lobby",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    watchDraft(client, "short-lobby-backoff");
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(setChannel).toHaveBeenCalledTimes(4);
+
+    await jest.advanceTimersByTimeAsync(3500);
+    expect(setChannel.mock.calls.length).toBeGreaterThan(4);
+
+    __testables.stopWatchingDraft("short-lobby-backoff");
   });
 });


### PR DESCRIPTION
## Summary
- Improve draft voice move speed for larger lobbies by increasing safe concurrency and deduping move tasks.
- Add cache-first guild member resolution to reduce fetch overhead during moves.
- Harden transient retry behavior with retry_after-aware delays and fast phase re-attempt cadence.
- Extend tests to cover both move directions (lobby->teams and teams->lobby) under retry pressure.

## Why
Large drafts (14–16 users) could split into visible move waves due to retry timing and API pressure. This change reduces long-tail move delays and improves consistency without sacrificing idempotency/safety.

## Test Plan
- [x] `npm test -- src/utils/draftWatcher.test.js`
- [x] `npm test`
- [x] Confirmed tests include winner-triggered lobby-return retries.